### PR TITLE
Add dtb files for ARM boot

### DIFF
--- a/boot/freeldr/freeldr/pcat.cmake
+++ b/boot/freeldr/freeldr/pcat.cmake
@@ -254,3 +254,11 @@ else()
 endif()
 
 add_cd_file(TARGET freeldr FILE ${CMAKE_CURRENT_BINARY_DIR}/freeldr.sys DESTINATION loader NO_CAB NOT_IN_HYBRIDCD FOR bootcd livecd hybridcd regtest)
+
+if(ARCH STREQUAL "arm")
+    # ARM32 PORT: Ship device tree blobs with ARM builds
+    file(GLOB ARM_DTB_FILES ${REACTOS_SOURCE_DIR}/misc/dtb/*.dtb)
+    foreach(_dtb ${ARM_DTB_FILES})
+        add_cd_file(FILE ${_dtb} DESTINATION loader NO_CAB FOR bootcd livecd hybridcd regtest)
+    endforeach()
+endif()

--- a/boot/freeldr/freeldr/uefi.cmake
+++ b/boot/freeldr/freeldr/uefi.cmake
@@ -147,3 +147,11 @@ if(RUNTIME_CHECKS)
 endif()
 
 add_dependencies(uefildr xdk)
+
+if(ARCH STREQUAL "arm")
+    # ARM32 PORT: Ship device tree blobs with ARM builds
+    file(GLOB ARM_DTB_FILES ${REACTOS_SOURCE_DIR}/misc/dtb/*.dtb)
+    foreach(_dtb ${ARM_DTB_FILES})
+        add_cd_file(FILE ${_dtb} DESTINATION loader NO_CAB FOR bootcd livecd hybridcd regtest)
+    endforeach()
+endif()


### PR DESCRIPTION
## Summary
- package miscellaneous dtb blobs in ARM freeldr builds
- ensure UEFI and BIOS boot flows ship the device tree blobs

## Testing
- `cmake -B build_arm -G Ninja -DARCH=arm -DCMAKE_TOOLCHAIN_FILE=toolchain-gcc.cmake` *(fails: arm-mingw32ce-gcc not found)*
- `cmake -B build_i386 -G Ninja -DARCH=i386` *(fails: Could NOT find BISON)*

------
https://chatgpt.com/codex/tasks/task_e_684b2aa18ea88331a340cbff402e2464