### PR TITLE
Fix implicit POSIX declarations

### DIFF
--- a/arm_support_port/sdk/tools/nandflash/nandflash.h
+++ b/arm_support_port/sdk/tools/nandflash/nandflash.h
@@ -11,6 +11,9 @@
 #include <string.h>
 #include <stdio.h>
 #include <fcntl.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 #include <typedefs.h>
 
 /* NAND Image Sizes */

--- a/base/applications/network/ftp/precomp.h
+++ b/base/applications/network/ftp/precomp.h
@@ -28,6 +28,9 @@
 #include <io.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 #include "ftp_var.h"
 

--- a/sdk/lib/3rdparty/libmpg123/compat/compat.c
+++ b/sdk/lib/3rdparty/libmpg123/compat/compat.c
@@ -16,6 +16,9 @@
 
 #ifdef _MSC_VER
 #include <io.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 #if(defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_APP))
 #define WINDOWS_UWP

--- a/sdk/lib/3rdparty/libmpg123/libmpg123.c
+++ b/sdk/lib/3rdparty/libmpg123/libmpg123.c
@@ -9,6 +9,9 @@
 #include "mpg123lib_intern.h"
 #include "icy2utf8.h"
 #include "debug.h"
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 #include "gapless.h"
 /* Want accurate rounding function regardless of decoder setup. */

--- a/sdk/lib/3rdparty/libxml2/debugXML.c
+++ b/sdk/lib/3rdparty/libxml2/debugXML.c
@@ -13,6 +13,9 @@
 
 #include <string.h>
 #include <stdlib.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 #include <libxml/xmlmemory.h>
 #include <libxml/tree.h>

--- a/sdk/lib/3rdparty/zlib/gzwrite.c
+++ b/sdk/lib/3rdparty/zlib/gzwrite.c
@@ -4,6 +4,9 @@
  */
 
 #include "gzguts.h"
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 /* Local functions */
 local int gz_init OF((gz_statep));

--- a/sdk/lib/crt/precomp.h
+++ b/sdk/lib/crt/precomp.h
@@ -23,6 +23,9 @@
 #include <math.h>
 #include <limits.h>
 #include <io.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 #include <sys/stat.h>
 #include <sys/locking.h>

--- a/sdk/lib/fslib/vfatlib/check/io.h
+++ b/sdk/lib/fslib/vfatlib/check/io.h
@@ -29,6 +29,9 @@
 
 #ifndef __REACTOS__
 #include <fcntl.h>		/* for off_t */
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 #endif
 
 #ifndef __REACTOS__

--- a/sdk/tools/isohybrid/isohybrid.c
+++ b/sdk/tools/isohybrid/isohybrid.c
@@ -34,7 +34,9 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
-//#include <unistd.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 #include <sys/stat.h>
 //#include <inttypes.h>
 #ifdef REACTOS_ISOHYBRID_EFI_MAC_SUPPORT

--- a/sdk/tools/mkisofs/schilytools/libschily/stdio/niwrite.c
+++ b/sdk/tools/mkisofs/schilytools/libschily/stdio/niwrite.c
@@ -17,6 +17,9 @@
  */
 
 #include "schilyio.h"
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 EXPORT ssize_t
 _niwrite(f, buf, count)

--- a/sdk/tools/mkisofs/schilytools/mkisofs/boot.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/boot.c
@@ -30,6 +30,9 @@ static	UConst char sccsid[] =
 #include <schily/utypes.h>
 #include <schily/intcvt.h>
 #include <schily/schily.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 #include "sunlabel.h"
 
 extern	int	use_sunx86boot;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/eltorito.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/eltorito.c
@@ -37,6 +37,9 @@ static	UConst char sccsid[] =
 #include "diskmbr.h"
 #include "bootinfo.h"
 #include <schily/schily.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 #undef MIN
 #define	MIN(a, b) (((a) < (b))? (a): (b))

--- a/sdk/tools/mkisofs/schilytools/mkisofs/joliet.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/joliet.c
@@ -88,6 +88,9 @@ static	UConst char sccsid[] =
 #include <schily/utypes.h>
 #include <schily/intcvt.h>
 #include <schily/schily.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 #include <schily/errno.h>
 
 LOCAL	Uint		jpath_table_index;

--- a/sdk/tools/mkisofs/schilytools/mkisofs/mkisofs.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/mkisofs.c
@@ -53,6 +53,9 @@ static	UConst char sccsid[] =
 #endif
 
 #include <schily/io.h>				/* for setmode() prototype */
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 #include <schily/getargs.h>
 
 #ifdef VMS

--- a/sdk/tools/mkisofs/schilytools/mkisofs/stream.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/stream.c
@@ -28,6 +28,9 @@ static	UConst char sccsid[] =
 #include "mkisofs.h"
 #include "iso9660.h"
 #include <schily/schily.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 LOCAL int	size_str_file	__PR((UInt32_t starting_extent));
 LOCAL int	size_str_dir	__PR((UInt32_t starting_extent));

--- a/sdk/tools/mkisofs/schilytools/mkisofs/write.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/write.c
@@ -39,6 +39,9 @@ static	UConst char sccsid[] =
 #endif /* SORTING */
 #include <schily/errno.h>
 #include <schily/schily.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 #include <schily/checkerr.h>
 #ifdef DVD_AUD_VID
 #include "dvd_reader.h"

--- a/sdk/tools/widl/utils.c
+++ b/sdk/tools/widl/utils.c
@@ -28,6 +28,9 @@
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 #include "widl.h"
 #include "utils.h"


### PR DESCRIPTION
## Summary
- include `<unistd.h>` in sources that use POSIX functions
- keep compatibility with MSVC using `_MSC_VER`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b8338caec83318e9559e65cb5aad8