### PR TITLE
Add WinPE hybrid packaging

### DIFF
--- a/.github/workflow/build.yml
+++ b/.github/workflow/build.yml
@@ -1,6 +1,38 @@
+name: Build ARM MSVC
+
+on:
+  push:
+  pull_request:
+
 jobs:
   cancel-everything:
     runs-on: ubuntu-latest
     steps:
       - name: No, thanks
         run: echo "Bye matrix!"
+
+  build-msvc-arm:
+    runs-on: windows-2022
+    needs: cancel-everything
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_arm
+      - name: Configure MSVC ARM build
+        run: .\configure.cmd VSSolution -DARCH=arm
+      - name: Build ReactOS
+        run: ninja bootcd
+      - name: Package WinPE Hybrid
+        shell: pwsh
+        run: .\scripts\winpe-package.ps1 -BuildDir $PWD -Output reactos-msvc14-arm-WinPE.zip
+      - name: Upload ISO
+        uses: actions/upload-artifact@v3
+        with:
+          name: reactos-arm-bootcd
+          path: bootcd.iso
+      - name: Upload WinPE Hybrid
+        uses: actions/upload-artifact@v3
+        with:
+          name: reactos-msvc14-arm-WinPE
+          path: reactos-msvc14-arm-WinPE.zip

--- a/scripts/winpe-package.ps1
+++ b/scripts/winpe-package.ps1
@@ -1,0 +1,54 @@
+Param(
+    [string]$BuildDir = '.',
+    [string]$Output = 'reactos-msvc14-arm-WinPE.zip'
+)
+
+$Staging = Join-Path $BuildDir 'winpe-hybrid'
+$ReactDir = Join-Path $Staging 'react'
+$DllDir = Join-Path $ReactDir 'dlls'
+
+Remove-Item $Staging -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $DllDir -Force | Out-Null
+
+# Basic applications to include
+$apps = @(
+    'base\applications\cmd\cmd.exe',
+    'base\applications\explorer\explorer.exe',
+    'base\applications\taskmgr\taskmgr.exe'
+)
+
+foreach ($app in $apps) {
+    $src = Join-Path $BuildDir $app
+    if (Test-Path $src) {
+        Copy-Item $src $ReactDir -Force
+    }
+}
+
+# Optional: copy DLLs if present
+$systemDir = Join-Path $BuildDir 'dll'
+if (Test-Path $systemDir) {
+    Get-ChildItem $systemDir -Filter '*.dll' | ForEach-Object {
+        Copy-Item $_.FullName $DllDir -Force
+    }
+}
+
+# Create autorun script
+$autorun = @"
+@echo off
+if exist react\explorer.exe (
+  start "" react\explorer.exe
+) else (
+  react\cmd.exe
+)
+"@
+$autorunPath = Join-Path $Staging 'autorun.cmd'
+Set-Content -Path $autorunPath -Value $autorun -Encoding ASCII
+
+# Create template winpeshl.ini
+$winpeshl = '[LaunchApps]\nreact\\explorer.exe'
+Set-Content -Path (Join-Path $Staging 'winpeshl.ini') -Value $winpeshl -Encoding ASCII
+
+# Compress archive
+if (Test-Path $Output) { Remove-Item $Output -Force }
+Compress-Archive -Path $Staging\* -DestinationPath $Output
+Write-Host "Created $Output"


### PR DESCRIPTION
## Summary
- package a minimal WinPE hybrid from the ARM MSVC build output
- upload the WinPE hybrid zip as a separate artifact in the build workflow

## Testing
- `pwsh -NoLogo -NoProfile -Command "& ./scripts/winpe-package.ps1 -BuildDir . -Output test.zip"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c189ad0cc8331b2665435fc869a4c